### PR TITLE
解决代码编译部署以后，从跟目录跳转到页面详情 左侧边栏不打开

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 node_modules/*
 dist/*
+data/
+.vscode/

--- a/src/coms/sider/index.jsx
+++ b/src/coms/sider/index.jsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
 
-import {toc as getToc} from '../../services';
+import {toc as getToc, getFirstSlugByToc} from '../../services';
 import {toTreeToc, isJumpableSlug, getPathToParent, getDocKey} from './util';
 
 import styles from './index.less';
@@ -29,6 +29,9 @@ class Sider extends React.Component{
     let expanded = [];
     if(this.props.defaultSlug){
       expanded = getPathToParent(treeToc, toc, this.props.defaultSlug);
+    } else {
+      const firstSlug = getFirstSlugByToc(toc);
+      expanded = getPathToParent(treeToc, toc, firstSlug);
     }
 
     this.setState({

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -21,3 +21,14 @@ export const getFirstSlug = async () => {
 export const book = async () => {
   return request.get(`${baseUrl}/book.json`).then(d => d.body);
 }
+
+export const getFirstSlugByToc = result => {
+  if (!result) {
+    return "";
+  }
+  for (let toc of result) {
+    if (toc.slug !== "#") {
+      return toc.slug;
+    }
+  }
+};


### PR DESCRIPTION
# 录屏详情
![GIF](https://user-images.githubusercontent.com/13914829/55374654-db2b7300-553b-11e9-8a3e-81436c1eb756.gif)
#解决以后的效果
![solved](https://user-images.githubusercontent.com/13914829/55374741-25acef80-553c-11e9-8b88-44f67c0e4590.gif)
